### PR TITLE
Implement Missing Tags

### DIFF
--- a/src/main/generated/data/c/tags/block/ores/nebulite.json
+++ b/src/main/generated/data/c/tags/block/ores/nebulite.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "enderscape:nebulite_ore",
+    "enderscape:mirestone_nebulite_ore"
+  ]
+}

--- a/src/main/generated/data/c/tags/block/ores/shadoline.json
+++ b/src/main/generated/data/c/tags/block/ores/shadoline.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "enderscape:shadoline_ore",
+    "enderscape:mirestone_shadoline_ore"
+  ]
+}

--- a/src/main/generated/data/c/tags/block/storage_blocks/nebulite.json
+++ b/src/main/generated/data/c/tags/block/storage_blocks/nebulite.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "enderscape:nebulite_block"
+  ]
+}

--- a/src/main/generated/data/c/tags/block/storage_blocks/raw_shadoline.json
+++ b/src/main/generated/data/c/tags/block/storage_blocks/raw_shadoline.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "enderscape:raw_shadoline_block"
+  ]
+}

--- a/src/main/generated/data/c/tags/block/storage_blocks/shadoline.json
+++ b/src/main/generated/data/c/tags/block/storage_blocks/shadoline.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "enderscape:shadoline_block"
+  ]
+}

--- a/src/main/generated/data/c/tags/item/drink_containing/bottle.json
+++ b/src/main/generated/data/c/tags/item/drink_containing/bottle.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "enderscape:drift_jelly_bottle"
+  ]
+}

--- a/src/main/generated/data/c/tags/item/drinks.json
+++ b/src/main/generated/data/c/tags/item/drinks.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "enderscape:drift_jelly_bottle"
+  ]
+}

--- a/src/main/generated/data/c/tags/item/drinks/drift_jelly.json
+++ b/src/main/generated/data/c/tags/item/drinks/drift_jelly.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "enderscape:drift_jelly_bottle"
+  ]
+}

--- a/src/main/generated/data/c/tags/item/drinks/magic.json
+++ b/src/main/generated/data/c/tags/item/drinks/magic.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "enderscape:drift_jelly_bottle"
+  ]
+}

--- a/src/main/generated/data/c/tags/item/foods/berry.json
+++ b/src/main/generated/data/c/tags/item/foods/berry.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "enderscape:flanger_berry"
+  ]
+}

--- a/src/main/generated/data/c/tags/item/foods/fruit.json
+++ b/src/main/generated/data/c/tags/item/foods/fruit.json
@@ -1,5 +1,0 @@
-{
-  "values": [
-    "enderscape:flanger_berry"
-  ]
-}

--- a/src/main/generated/data/c/tags/item/gems/nebulite.json
+++ b/src/main/generated/data/c/tags/item/gems/nebulite.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "enderscape:nebulite"
+  ]
+}

--- a/src/main/generated/data/c/tags/item/ingots/shadoline.json
+++ b/src/main/generated/data/c/tags/item/ingots/shadoline.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "enderscape:shadoline_ingot"
+  ]
+}

--- a/src/main/generated/data/c/tags/item/ores/nebulite.json
+++ b/src/main/generated/data/c/tags/item/ores/nebulite.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "enderscape:nebulite_ore",
+    "enderscape:mirestone_nebulite_ore"
+  ]
+}

--- a/src/main/generated/data/c/tags/item/ores/shadoline.json
+++ b/src/main/generated/data/c/tags/item/ores/shadoline.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "enderscape:shadoline_ore",
+    "enderscape:mirestone_shadoline_ore"
+  ]
+}

--- a/src/main/generated/data/c/tags/item/raw_materials.json
+++ b/src/main/generated/data/c/tags/item/raw_materials.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "enderscape:raw_shadoline"
+  ]
+}

--- a/src/main/generated/data/c/tags/item/raw_materials/shadoline.json
+++ b/src/main/generated/data/c/tags/item/raw_materials/shadoline.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "enderscape:raw_shadoline"
+  ]
+}

--- a/src/main/generated/data/c/tags/item/storage_blocks/nebulite.json
+++ b/src/main/generated/data/c/tags/item/storage_blocks/nebulite.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "enderscape:nebulite_block"
+  ]
+}

--- a/src/main/generated/data/c/tags/item/storage_blocks/raw_shadoline.json
+++ b/src/main/generated/data/c/tags/item/storage_blocks/raw_shadoline.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "enderscape:raw_shadoline_block"
+  ]
+}

--- a/src/main/generated/data/c/tags/item/storage_blocks/shadoline.json
+++ b/src/main/generated/data/c/tags/item/storage_blocks/shadoline.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "enderscape:shadoline_block"
+  ]
+}

--- a/src/main/generated/data/minecraft/tags/block/flowers.json
+++ b/src/main/generated/data/minecraft/tags/block/flowers.json
@@ -1,5 +1,6 @@
 {
   "values": [
-    "enderscape:wisp_flower"
+    "enderscape:wisp_flower",
+    "enderscape:flanger_berry_flower"
   ]
 }

--- a/src/main/generated/data/minecraft/tags/block/replaceable.json
+++ b/src/main/generated/data/minecraft/tags/block/replaceable.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    "enderscape:dry_end_growth",
+    "enderscape:wisp_sprouts",
+    "enderscape:wisp_growth"
+  ]
+}

--- a/src/main/generated/data/minecraft/tags/block/saplings.json
+++ b/src/main/generated/data/minecraft/tags/block/saplings.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "enderscape:veiled_sapling"
+  ]
+}

--- a/src/main/generated/data/minecraft/tags/block/tall_flowers.json
+++ b/src/main/generated/data/minecraft/tags/block/tall_flowers.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "enderscape:wisp_flower"
+  ]
+}

--- a/src/main/generated/data/minecraft/tags/item/flowers.json
+++ b/src/main/generated/data/minecraft/tags/item/flowers.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "enderscape:flanger_berry_flower",
+    "enderscape:wisp_flower"
+  ]
+}

--- a/src/main/generated/data/minecraft/tags/item/leaves.json
+++ b/src/main/generated/data/minecraft/tags/item/leaves.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "enderscape:veiled_leaves"
+  ]
+}

--- a/src/main/generated/data/minecraft/tags/item/saplings.json
+++ b/src/main/generated/data/minecraft/tags/item/saplings.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "enderscape:veiled_sapling"
+  ]
+}

--- a/src/main/generated/data/minecraft/tags/item/tall_flowers.json
+++ b/src/main/generated/data/minecraft/tags/item/tall_flowers.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "enderscape:wisp_flower"
+  ]
+}

--- a/src/main/java/net/bunten/enderscape/datagen/EnderscapeBlockTagProvider.java
+++ b/src/main/java/net/bunten/enderscape/datagen/EnderscapeBlockTagProvider.java
@@ -127,15 +127,19 @@ public class EnderscapeBlockTagProvider extends FabricTagProvider<Block> {
         getOrCreateTagBuilder(BlockTags.FALL_DAMAGE_RESETTING).add(VEILED_LEAF_PILE);
         getOrCreateTagBuilder(BlockTags.FEATURES_CANNOT_REPLACE).add(END_TRIAL_SPAWNER, END_VAULT);
         getOrCreateTagBuilder(BlockTags.FENCE_GATES).add(VEILED_FENCE_GATE, CELESTIAL_FENCE_GATE, MURUBLIGHT_FENCE_GATE);
-        getOrCreateTagBuilder(BlockTags.FLOWERS).add(WISP_FLOWER);
+        getOrCreateTagBuilder(BlockTags.TALL_FLOWERS).add(WISP_FLOWER);
+        getOrCreateTagBuilder(BlockTags.FLOWERS).add(WISP_FLOWER, FLANGER_BERRY_FLOWER);
         getOrCreateTagBuilder(BlockTags.FLOWER_POTS).add(POTTED_ALLURING_MAGNIA_SPROUT, POTTED_BLINKLIGHT, POTTED_BULB_FLOWER, POTTED_CELESTIAL_CHANTERELLE, POTTED_CELESTIAL_GROWTH, POTTED_CHORUS_SPROUTS, POTTED_CORRUPT_GROWTH, POTTED_MURUBLIGHT_CHANTERELLE, POTTED_REPULSIVE_MAGNIA_SPROUT, POTTED_DRY_END_GROWTH, POTTED_VEILED_SAPLING, POTTED_WISP_GROWTH);
         getOrCreateTagBuilder(BlockTags.LEAVES).add(VEILED_LEAVES);
+        getOrCreateTagBuilder(BlockTags.SAPLINGS).add(VEILED_SAPLING);
         getOrCreateTagBuilder(BlockTags.LOGS_THAT_BURN).forceAddTag(VEILED_LOGS).forceAddTag(CELESTIAL_STEMS).forceAddTag(MURUBLIGHT_STEMS);
         getOrCreateTagBuilder(BlockTags.MUSHROOM_GROW_BLOCK).forceAddTag(OVERGROWTH_BLOCKS);
         getOrCreateTagBuilder(BlockTags.NEEDS_DIAMOND_TOOL).add(NEBULITE_ORE, MIRESTONE_NEBULITE_ORE, NEBULITE_BLOCK);
         getOrCreateTagBuilder(BlockTags.NEEDS_STONE_TOOL).add(SHADOLINE_ORE, MIRESTONE_SHADOLINE_ORE).forceAddTag(SHADOLINE_BLOCKS).forceAddTag(MAGNIA_BLOCKS).forceAddTag(MAGNIA_SPROUTS);
         getOrCreateTagBuilder(BlockTags.PLANKS).add(VEILED_PLANKS, CELESTIAL_PLANKS, MURUBLIGHT_PLANKS);
         getOrCreateTagBuilder(BlockTags.SMALL_FLOWERS).add(BULB_FLOWER);
+        getOrCreateTagBuilder(BlockTags.REPLACEABLE).add(DRY_END_GROWTH, WISP_SPROUTS, WISP_GROWTH);
+
 
         getOrCreateTagBuilder(BlockTags.SLABS).add(
                 CELESTIAL_BRICK_SLAB,
@@ -220,6 +224,12 @@ public class EnderscapeBlockTagProvider extends FabricTagProvider<Block> {
         getOrCreateTagBuilder(STRIPPED_WOODS).add(STRIPPED_VEILED_WOOD, STRIPPED_CELESTIAL_HYPHAE, STRIPPED_MURUBLIGHT_HYPHAE);
         getOrCreateTagBuilder(ORES).add(NEBULITE_ORE, SHADOLINE_ORE, MIRESTONE_NEBULITE_ORE, MIRESTONE_SHADOLINE_ORE);
         getOrCreateTagBuilder(STORAGE_BLOCKS).add(SHADOLINE_BLOCK, NEBULITE_BLOCK, DRIFT_JELLY_BLOCK);
+
+        getOrCreateTagBuilder(STORAGE_BLOCKS_NEBULITE).add(NEBULITE_BLOCK);
+        getOrCreateTagBuilder(STORAGE_BLOCKS_SHADOLINE).add(SHADOLINE_BLOCK);
+        getOrCreateTagBuilder(STORAGE_BLOCKS_RAW_SHADOLINE).add(RAW_SHADOLINE_BLOCK);
+        getOrCreateTagBuilder(NEBULITE_ORES).add(NEBULITE_ORE, MIRESTONE_NEBULITE_ORE);
+        getOrCreateTagBuilder(SHADOLINE_ORES).add(SHADOLINE_ORE, MIRESTONE_SHADOLINE_ORE);
 
         getOrCreateTagBuilder(externalKey("antixray", "hidden_only_ores")).add(NEBULITE_ORE, MIRESTONE_NEBULITE_ORE);
 

--- a/src/main/java/net/bunten/enderscape/datagen/EnderscapeItemTagProvider.java
+++ b/src/main/java/net/bunten/enderscape/datagen/EnderscapeItemTagProvider.java
@@ -72,11 +72,15 @@ public class EnderscapeItemTagProvider extends FabricTagProvider<Item> {
         getOrCreateTagBuilder(ItemTags.FENCE_GATES).add(CELESTIAL_FENCE_GATE.asItem(), MURUBLIGHT_FENCE_GATE.asItem());
         getOrCreateTagBuilder(HANGING_SIGNS).add(VEILED_HANGING_SIGN_ITEM.asItem(), CELESTIAL_HANGING_SIGN_ITEM, MURUBLIGHT_HANGING_SIGN_ITEM);
         getOrCreateTagBuilder(LEG_ARMOR).add(DRIFT_LEGGINGS);
+        getOrCreateTagBuilder(SAPLINGS).add(VEILED_SAPLING.asItem());
+        getOrCreateTagBuilder(LEAVES).add(VEILED_LEAVES.asItem());
         getOrCreateTagBuilder(LOGS_THAT_BURN).forceAddTag(VEILED_LOGS).forceAddTag(CELESTIAL_STEMS).forceAddTag(MURUBLIGHT_STEMS);
         getOrCreateTagBuilder(PLANKS).add(VEILED_PLANKS.asItem(), CELESTIAL_PLANKS.asItem(), MURUBLIGHT_PLANKS.asItem());
         getOrCreateTagBuilder(SIGNS).add(VEILED_SIGN_ITEM.asItem(), CELESTIAL_SIGN_ITEM, MURUBLIGHT_SIGN_ITEM);
         getOrCreateTagBuilder(SLABS).add(VEILED_SLAB.asItem(), CELESTIAL_SLAB.asItem(), CELESTIAL_BRICK_SLAB.asItem(), MURUBLIGHT_SLAB.asItem(), MURUBLIGHT_BRICK_SLAB.asItem(), VERADITE_SLAB.asItem(), POLISHED_VERADITE_SLAB.asItem(), VERADITE_BRICK_SLAB.asItem(), KURODITE_SLAB.asItem(), POLISHED_KURODITE_SLAB.asItem(), KURODITE_BRICK_SLAB.asItem(), SHADOLINE_BLOCK_SLAB.asItem(), CUT_SHADOLINE_SLAB.asItem());
         getOrCreateTagBuilder(SMALL_FLOWERS).add(BULB_FLOWER.asItem());
+        getOrCreateTagBuilder(TALL_FLOWERS).add(WISP_FLOWER.asItem());
+        getOrCreateTagBuilder(FLOWERS).add(FLANGER_BERRY_FLOWER.asItem(), WISP_FLOWER.asItem());
         getOrCreateTagBuilder(STAIRS).add(VEILED_STAIRS.asItem(), CELESTIAL_STAIRS.asItem(), CELESTIAL_BRICK_STAIRS.asItem(), MURUBLIGHT_STAIRS.asItem(), MURUBLIGHT_BRICK_STAIRS.asItem(), VERADITE_STAIRS.asItem(), POLISHED_VERADITE_STAIRS.asItem(), VERADITE_BRICK_STAIRS.asItem(), KURODITE_STAIRS.asItem(), POLISHED_KURODITE_STAIRS.asItem(), KURODITE_BRICK_STAIRS.asItem(), SHADOLINE_BLOCK_STAIRS.asItem(), CUT_SHADOLINE_STAIRS.asItem());
         getOrCreateTagBuilder(STONE_BUTTONS).add(POLISHED_VERADITE_BUTTON.asItem(), POLISHED_KURODITE_BUTTON.asItem());
         getOrCreateTagBuilder(STONE_CRAFTING_MATERIALS).add(END_STONE.asItem(), VERADITE.asItem(), MIRESTONE.asItem(), KURODITE.asItem());
@@ -97,12 +101,23 @@ public class EnderscapeItemTagProvider extends FabricTagProvider<Item> {
         getOrCreateTagBuilder(EDIBLE_WHEN_PLACED_FOODS).add(CHORUS_CAKE_ROLL_ITEM);
         getOrCreateTagBuilder(FOODS).add(DRIFT_JELLY_BOTTLE);
         getOrCreateTagBuilder(FRUIT_FOODS).add(FLANGER_BERRY);
+        getOrCreateTagBuilder(BERRY_FOODS).add(FLANGER_BERRY);
         getOrCreateTagBuilder(GEMS).add(NEBULITE);
         getOrCreateTagBuilder(INGOTS).add(SHADOLINE_INGOT);
+        getOrCreateTagBuilder(RAW_MATERIALS).add(RAW_SHADOLINE);
         getOrCreateTagBuilder(MUSIC_DISCS).add(MUSIC_DISC_GLARE, MUSIC_DISC_DECAY, MUSIC_DISC_BLISS);
         getOrCreateTagBuilder(SHIELD_TOOLS).add(END_STONE_RUBBLE_SHIELD, VERADITE_RUBBLE_SHIELD, MIRESTONE_RUBBLE_SHIELD, KURODITE_RUBBLE_SHIELD);
         getOrCreateTagBuilder(STORAGE_BLOCKS).add(SHADOLINE_BLOCK.asItem(), NEBULITE_BLOCK.asItem(), DRIFT_JELLY_BLOCK.asItem());
         getOrCreateTagBuilder(TOOLS).add(MIRROR, MAGNIA_ATTRACTOR);
+
+        getOrCreateTagBuilder(STORAGE_BLOCKS_NEBULITE).add(NEBULITE_BLOCK.asItem());
+        getOrCreateTagBuilder(STORAGE_BLOCKS_SHADOLINE).add(SHADOLINE_BLOCK.asItem());
+        getOrCreateTagBuilder(STORAGE_BLOCKS_RAW_SHADOLINE).add(RAW_SHADOLINE_BLOCK.asItem());
+        getOrCreateTagBuilder(NEBULITE_ORES).add(NEBULITE_ORE.asItem(), MIRESTONE_NEBULITE_ORE.asItem());
+        getOrCreateTagBuilder(SHADOLINE_ORES).add(SHADOLINE_ORE.asItem(), MIRESTONE_SHADOLINE_ORE.asItem());
+        getOrCreateTagBuilder(GEMS_NEBULITE).add(NEBULITE);
+        getOrCreateTagBuilder(INGOTS_SHADOLINE).add(SHADOLINE_INGOT);
+        getOrCreateTagBuilder(RAW_ORE_SHADOLINE).add(RAW_SHADOLINE);
 
         getOrCreateTagBuilder(externalKey("create", "upright_on_belt")).add(DRIFT_JELLY_BOTTLE);
         getOrCreateTagBuilder(externalKey("create", "deployable_drink")).add(DRIFT_JELLY_BOTTLE);

--- a/src/main/java/net/bunten/enderscape/datagen/EnderscapeItemTagProvider.java
+++ b/src/main/java/net/bunten/enderscape/datagen/EnderscapeItemTagProvider.java
@@ -100,6 +100,10 @@ public class EnderscapeItemTagProvider extends FabricTagProvider<Item> {
         getOrCreateTagBuilder(BUCKETS).add(RUSTLE_BUCKET);
         getOrCreateTagBuilder(EDIBLE_WHEN_PLACED_FOODS).add(CHORUS_CAKE_ROLL_ITEM);
         getOrCreateTagBuilder(FOODS).add(DRIFT_JELLY_BOTTLE);
+        getOrCreateTagBuilder(DRINKS).add(DRIFT_JELLY_BOTTLE);
+        getOrCreateTagBuilder(DRINK_CONTAINING_BOTTLE).add(DRIFT_JELLY_BOTTLE);
+        getOrCreateTagBuilder(MAGIC_DRINKS).add(DRIFT_JELLY_BOTTLE);
+        getOrCreateTagBuilder(DRIFT_JELLY_DRINKS).add(DRIFT_JELLY_BOTTLE);
         getOrCreateTagBuilder(BERRY_FOODS).add(FLANGER_BERRY);
         getOrCreateTagBuilder(GEMS).add(NEBULITE);
         getOrCreateTagBuilder(INGOTS).add(SHADOLINE_INGOT);

--- a/src/main/java/net/bunten/enderscape/datagen/EnderscapeItemTagProvider.java
+++ b/src/main/java/net/bunten/enderscape/datagen/EnderscapeItemTagProvider.java
@@ -100,7 +100,6 @@ public class EnderscapeItemTagProvider extends FabricTagProvider<Item> {
         getOrCreateTagBuilder(BUCKETS).add(RUSTLE_BUCKET);
         getOrCreateTagBuilder(EDIBLE_WHEN_PLACED_FOODS).add(CHORUS_CAKE_ROLL_ITEM);
         getOrCreateTagBuilder(FOODS).add(DRIFT_JELLY_BOTTLE);
-        getOrCreateTagBuilder(FRUIT_FOODS).add(FLANGER_BERRY);
         getOrCreateTagBuilder(BERRY_FOODS).add(FLANGER_BERRY);
         getOrCreateTagBuilder(GEMS).add(NEBULITE);
         getOrCreateTagBuilder(INGOTS).add(SHADOLINE_INGOT);

--- a/src/main/java/net/bunten/enderscape/registry/tag/EnderscapeBlockTags.java
+++ b/src/main/java/net/bunten/enderscape/registry/tag/EnderscapeBlockTags.java
@@ -2,6 +2,7 @@ package net.bunten.enderscape.registry.tag;
 
 import net.bunten.enderscape.Enderscape;
 import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.level.block.Block;
 
@@ -54,7 +55,18 @@ public class EnderscapeBlockTags {
     public static final TagKey<Block> VEILED_WOOD_TAG = register("veiled_wood");
     public static final TagKey<Block> VERADITE_BLOCKS = register("veradite_blocks");
 
+    // Common tags for better compat
+    public static final TagKey<Block> STORAGE_BLOCKS_NEBULITE = registerCommon("storage_blocks/nebulite");
+    public static final TagKey<Block> STORAGE_BLOCKS_SHADOLINE = registerCommon("storage_blocks/shadoline");
+    public static final TagKey<Block> STORAGE_BLOCKS_RAW_SHADOLINE = registerCommon("storage_blocks/raw_shadoline");
+    public static final TagKey<Block> NEBULITE_ORES = registerCommon("ores/nebulite");
+    public static final TagKey<Block> SHADOLINE_ORES = registerCommon("ores/shadoline");
+
     private static TagKey<Block> register(String name) {
         return TagKey.create(Registries.BLOCK, Enderscape.id(name));
+    }
+
+    private static TagKey<Block> registerCommon(String name) {
+        return TagKey.create(Registries.BLOCK, ResourceLocation.tryBuild("c", name));
     }
 }

--- a/src/main/java/net/bunten/enderscape/registry/tag/EnderscapeItemTags.java
+++ b/src/main/java/net/bunten/enderscape/registry/tag/EnderscapeItemTags.java
@@ -2,6 +2,7 @@ package net.bunten.enderscape.registry.tag;
 
 import net.bunten.enderscape.Enderscape;
 import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.Item;
 
@@ -38,7 +39,21 @@ public class EnderscapeItemTags {
     public static final TagKey<Item> VEILED_WOOD_TAG = register("veiled_wood");
     public static final TagKey<Item> VERADITE_BLOCKS = register("veradite_blocks");
 
+    // Common tags for better compat
+    public static final TagKey<Item> STORAGE_BLOCKS_NEBULITE = registerCommon("storage_blocks/nebulite");
+    public static final TagKey<Item> STORAGE_BLOCKS_SHADOLINE = registerCommon("storage_blocks/shadoline");
+    public static final TagKey<Item> STORAGE_BLOCKS_RAW_SHADOLINE = registerCommon("storage_blocks/raw_shadoline");
+    public static final TagKey<Item> NEBULITE_ORES = registerCommon("ores/nebulite");
+    public static final TagKey<Item> SHADOLINE_ORES = registerCommon("ores/shadoline");
+    public static final TagKey<Item> GEMS_NEBULITE = registerCommon("gems/nebulite");
+    public static final TagKey<Item> INGOTS_SHADOLINE = registerCommon("ingots/shadoline");
+    public static final TagKey<Item> RAW_ORE_SHADOLINE = registerCommon("raw_materials/shadoline");
+
     private static TagKey<Item> register(String name) {
         return TagKey.create(Registries.ITEM, Enderscape.id(name));
+    }
+
+    private static TagKey<Item> registerCommon(String name) {
+        return TagKey.create(Registries.ITEM, ResourceLocation.tryBuild("c", name));
     }
 }

--- a/src/main/java/net/bunten/enderscape/registry/tag/EnderscapeItemTags.java
+++ b/src/main/java/net/bunten/enderscape/registry/tag/EnderscapeItemTags.java
@@ -48,6 +48,7 @@ public class EnderscapeItemTags {
     public static final TagKey<Item> GEMS_NEBULITE = registerCommon("gems/nebulite");
     public static final TagKey<Item> INGOTS_SHADOLINE = registerCommon("ingots/shadoline");
     public static final TagKey<Item> RAW_ORE_SHADOLINE = registerCommon("raw_materials/shadoline");
+    public static final TagKey<Item> DRIFT_JELLY_DRINKS = registerCommon("drinks/drift_jelly");
 
     private static TagKey<Item> register(String name) {
         return TagKey.create(Registries.ITEM, Enderscape.id(name));


### PR DESCRIPTION
This PR should implement all of the missing tags I could find that would help with compat with other mods.
 - Implements several missing Minecraft tags, incl. `minecraft:tall_flowers` for Wisp Flower
 - Implements several missing Common tags, incl. `c:foods/berry` for Flanger Berries
 - Implements several missing Enderscape-specific Common tags for ingots/gems

None of these tags are _necessary_, only that they help significantly with other mods being able to identify the what's what and who's who of Enderscape significantly.

If you have concerns about specific tags and that you _don't_ want them; feel free to contact me on the Discord (same name) and I will endeavour to fix them in a timely manner.